### PR TITLE
Make response headers available when calling "_get"

### DIFF
--- a/lib/cloudapi.js
+++ b/lib/cloudapi.js
@@ -2031,7 +2031,7 @@ CloudAPI.prototype._get = function (req, callback, noCache) {
             log.debug(obj, util.format('CloudAPI._get(%s)', req.path));
         }
 
-        return callback(err, obj);
+        return callback(err, obj, res.headers);
     });
 };
 


### PR DESCRIPTION
Calling _get will return not only the response body but also the response headers, as they are useful in many situations. The Cloud API uses headers to include different kind of information (i.e. resource count, x-credentials-suppressed, X-Api-Version, X-Request-Id and X-Response-Time, etc) that are useful in may situations and are currently unavailable in SDC 6.5.x
