### PR TITLE
Make response headers available when calling "_get"

### DIFF
--- a/lib/cloudapi.js
+++ b/lib/cloudapi.js
@@ -2011,11 +2011,11 @@ CloudAPI.prototype._get = function (req, callback, noCache) {
     // Check the cache first
     if (!noCache) {
         var cached = this._cacheGet(req.path, req.cacheTTL);
-        if (cached) {
-            if (cached instanceof Error)
-                return callback(cached);
+        if (cached && cached.obj) {
+            if (cached.obj instanceof Error)
+                return callback(cached.obj);
 
-            return callback(null, cached);
+            return callback(null, cached.obj, cached.headers);
         }
     }
 
@@ -2027,11 +2027,11 @@ CloudAPI.prototype._get = function (req, callback, noCache) {
         }
 
         if (obj) {
-            self._cachePut(req.path, obj);
+            self._cachePut(req.path, {obj: obj, headers: res && res.headers});
             log.debug(obj, util.format('CloudAPI._get(%s)', req.path));
         }
 
-        return callback(err, obj, res.headers);
+        return callback(err, obj, res && res.headers);
     });
 };
 


### PR DESCRIPTION
Calling _get will return not only the response body but also the response headers, as they are useful in many situations. The Cloud API uses headers to include different kind of information (i.e. resource count, x-credentials-suppressed, X-Api-Version, X-Request-Id and X-Response-Time, etc) that are useful in may situations and are currently unavailable in SDC 6.5.x

Includes caching.
