### PR TITLE
Clarify format of --tag argument

### DIFF
--- a/lib/cli_common.js
+++ b/lib/cli_common.js
@@ -25,7 +25,7 @@ var MasterOptions = {
     url: 'url for SmartDataCenter API (i.e. https://someaddress.com)',
     name: 'the name of the entity',
     // tags
-    tag: 'key,value pair',
+    tag: 'key=value pair',
     // firewall
     enabled: 'enable entity',
     rule: 'firewall rule',


### PR DESCRIPTION
Make it clear that --tag expects key=value instead of key,value as its
argument.
