### PR TITLE
Clarify usage of sdc-createmachine --name

### DIFF
--- a/bin/sdc-createmachine
+++ b/bin/sdc-createmachine
@@ -48,7 +48,9 @@ var ShortOptions = {
 };
 
 var usageStr = common.buildUsageString(Options);
-usageStr += common.buildDetailedUsageString(Options);
+usageStr += common.buildDetailedUsageString(Options, {
+    'name': 'friendly name (may contain letters, numbers, dashes, and periods)'
+});
 
 // --- Mainline
 


### PR DESCRIPTION
Explain the allowed characters in machine names.
