### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The CLI commands typical work with JSON content. We suggest you also install
 the [`json` tool](https://github.com/trentm/json) for working with JSON on the
 command line. The examples below use `json` heavily.
 
-    npm install -g jsontool   # *not* 'npm install json'
+    npm install -g json
 
 
 # CLI Setup and Authentication


### PR DESCRIPTION
when trying to install ```jsontool``` I get the following warning:

```console
npm install -g jsontool
npm WARN deprecated jsontool@7.0.2: jsontool is now called simply 'json'.  Please update your dependencies.
```