### PR TITLE
Update dep to get newer dtrace-provider to fix build against node 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Joyent, Inc. http://www.joyent.com",
   "name": "smartdc",
   "description": "Client SDK and CLI for the Joyent SmartDataCenter API",
-  "version": "7.5.3",
+  "version": "7.5.4",
   "private": false,
   "homepage": "http://www.joyent.com/software/smartdatacenter",
   "repository": {
@@ -21,10 +21,10 @@
       "assert-plus": "0.1.5",
       "lru-cache": "2.2.0",
       "nopt": "2.0.0",
-      "restify": "2.8.5",
-      "bunyan": "1.3.4",
+      "restify": "4.0.3",
+      "bunyan": "1.5.1",
       "clone": "0.1.6",
-      "smartdc-auth": "2.1.5",
+      "smartdc-auth": "2.1.7",
       "cmdln": "3.2.1",
       "dashdash": "1.7.3",
       "vasync": "1.6.2"


### PR DESCRIPTION
`make check` passes.

Updating restify, bunyan and smartdc-auth fixes the following errors:

````
{ [Error: Cannot find module './build/Release/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }
{ [Error: Cannot find module './build/default/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }
{ [Error: Cannot find module './build/Debug/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }
{ [Error: Cannot find module './build/Release/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }
{ [Error: Cannot find module './build/default/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }
{ [Error: Cannot find module './build/Debug/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }
````