### PR TITLE
Updated docs to use correct ssh-keygen command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ the environment variable equivalents:
   output. You can calculate the fingerprint like this:
 
         ssh-keygen -l -f ~/.ssh/id_rsa.pub | awk '{print $2}' | tr -d '\n'
+        
+  On new versions of `ssh-keygen`, you have to specify which output format to use;
+  
+        ssh-keygen -E md5 -lf  ~/.ssh/id_rsa.pub  | awk '{print $2}'
 
   Your matching SSH *private* key must be beside the ".pub" public key file
   in your "~/.ssh" dir.


### PR DESCRIPTION
Some versions of `ssh-keygen` will not output MD5 by default, including the one which comes as default installed on MacOS El Capitan, resulting in errors such as "error: Fingerprint format is not supported, or is invalid". This fixes that problem.